### PR TITLE
Add confirm and checkbox question type

### DIFF
--- a/packages/scaffdog/.scaffdog/sandbox.md
+++ b/packages/scaffdog/.scaffdog/sandbox.md
@@ -2,6 +2,17 @@
 name: 'sandbox'
 root: '.'
 output: ['.', 'src/**/*']
+questions:
+  bool:
+    confirm: 'Yes of No'
+  array:
+    message: 'Please select elements'
+    multiple: true
+    choices:
+      - 'A'
+      - 'B'
+      - 'C'
+    initial: ['B', 'C']
 ---
 
 # Variables
@@ -13,10 +24,18 @@ output: ['.', 'src/**/*']
 ```typescript
 import { createCommand } from '{{ relative "../src/command" }}';
 
+{{ if inputs.bool -}}
+console.log('boolean: true');
+{{- else -}}
+console.log('boolean: false');
+{{- end }}
+{{ for v, i in inputs.array }}
+console.log('array: {{ i }} - {{ v }}');{{ end }}
+
 export default createCommand({
   name: '{{ name }}',
   key: '{{ name }}',
-  description: '{{ inputs.desc }}',
+  description: '{{ "TODO" }}',
   build: (yargs) => yargs,
 })(async ({ cwd, logger, options }) => {
   logger.debug(cwd, options);

--- a/packages/scaffdog/README.md
+++ b/packages/scaffdog/README.md
@@ -459,6 +459,21 @@ questions:
   key4:
     message: 'Message'
     choices: ['A', 'B', 'C']
+
+  # Using `checkbox` prompt.
+  key4:
+    message: 'Message'
+    multiple: true
+    choices: ['A', 'B', 'C']
+
+  # Using `confirm` prompt.
+  key5:
+    confirm: 'Message'
+
+  # Using `confirm` prompt, with default value.
+  key6:
+    confirm: 'Message'
+    initial: false
 ---
 ```
 

--- a/packages/scaffdog/fixtures/question.md
+++ b/packages/scaffdog/fixtures/question.md
@@ -1,0 +1,51 @@
+---
+name: 'question'
+root: 'tmp'
+output: '.'
+questions:
+  shorthand: 'shorthand'
+  input:
+    message: 'input'
+  input_with_initial:
+    message: 'input'
+    initial: 'input (initial)'
+  bool:
+    confirm: 'bool'
+  bool_with_true:
+    confirm: 'bool'
+    initial: true
+  bool_with_false:
+    confirm: 'bool'
+    initial: false
+  list:
+    message: 'list'
+    choices: ['A', 'B', 'C']
+  list_with_initial:
+    message: 'list'
+    choices: ['A', 'B', 'C']
+    initial: ['A', 'C']
+  checkbox:
+    message: 'checkbox'
+    multiple: true
+    choices: ['A', 'B', 'C']
+  checkbox_with_initial:
+    message: 'checkbox'
+    multiple: true
+    choices: ['A', 'B', 'C']
+    initial: ['B', 'C']
+---
+
+# `result.txt`
+
+```
+shorthand: {{ inputs.shorthand }}
+input: {{ inputs.input }}
+input_with_initial: {{ inputs.input_with_initial }}
+bool: {{ inputs.bool }}
+bool_with_true: {{ inputs.bool_with_true }}
+bool_with_false: {{ inputs.bool_with_false }}
+list: {{ inputs.list }}
+list_with_initial: {{ inputs.list_with_initial }}
+checkbox: {{ inputs.checkbox }}
+checkbox_with_initial: {{ inputs.checkbox_with_initial }}
+```

--- a/packages/scaffdog/src/cmds/__snapshots__/generate.test.ts.snap
+++ b/packages/scaffdog/src/cmds/__snapshots__/generate.test.ts.snap
@@ -1,65 +1,6 @@
 // Vitest Snapshot v1
 
-exports[`document > force overwrite 1`] = `
-"ℹ Output destination directory: \\".\\"
-
-🐶 Generated 2 files!
-
-     ✔ tmp/nest/dump.txt
-     ✔ tmp/generate.txt
-"
-`;
-
-exports[`document > name options 1`] = `
-"ℹ Output destination directory: \\".\\"
-
-🐶 Generated 2 files!
-
-     ✔ tmp/nest/dump.txt
-     ✔ tmp/generate.txt
-"
-`;
-
-exports[`document > not found 1`] = `
-"
- ERROR  Document \\"not-found\\" not found.
-
-"
-`;
-
-exports[`document > overwrite files 1`] = `
-"ℹ Output destination directory: \\".\\"
-
-🐶 Generated 1 file! (1 skipped)
-
-     ✔ tmp/nest/dump.txt
-     ⚠ tmp/generate.txt (skipped)
-"
-`;
-
-exports[`document > prompt 1`] = `
-"ℹ Output destination directory: \\".\\"
-
-🐶 Generated 2 files!
-
-     ✔ tmp/nest/dump.txt
-     ✔ tmp/generate.txt
-"
-`;
-
-exports[`document > prompt 2`] = `
-"a
-tmp/nest/dump.txt
-dump
-dump.txt
-.txt
-tmp/nest
-dump.txt
-
-../../snapshots/src"
-`;
-
-exports[`dry run 1`] = `
+exports[`options > dry run 1`] = `
 "ℹ Output destination directory: \\".\\"
 
 ───┬────────────────────────────────────────────────────────
@@ -87,11 +28,92 @@ exports[`dry run 1`] = `
 "
 `;
 
-exports[`has magic and question 1`] = `
+exports[`options > force overwrite 1`] = `
+"ℹ Output destination directory: \\".\\"
+
+🐶 Generated 2 files!
+
+     ✔ tmp/nest/dump.txt
+     ✔ tmp/generate.txt
+"
+`;
+
+exports[`options > not found 1`] = `
+"
+ ERROR  Document \\"not-found\\" not found.
+
+"
+`;
+
+exports[`options > options 1`] = `
+"ℹ Output destination directory: \\".\\"
+
+🐶 Generated 2 files!
+
+     ✔ tmp/nest/dump.txt
+     ✔ tmp/generate.txt
+"
+`;
+
+exports[`prompt > all question types 1`] = `
+"ℹ Output destination directory: \\"tmp\\"
+
+🐶 Generated 1 file!
+
+     ✔ tmp/result.txt
+"
+`;
+
+exports[`prompt > all question types 2`] = `
+"shorthand: shorthand
+input: input
+input_with_initial: input_with_initial
+bool: bool
+bool_with_true: bool_with_true
+bool_with_false: bool_with_false
+list: list
+list_with_initial: list_with_initial
+checkbox: checkbox
+checkbox_with_initial: checkbox_with_initial"
+`;
+
+exports[`prompt > has magic and question 1`] = `
 "ℹ Output destination directory: \\"tmp/root\\"
 
 🐶 Generated 1 file!
 
      ✔ tmp/root/b.txt
+"
+`;
+
+exports[`prompt > name 1`] = `
+"ℹ Output destination directory: \\".\\"
+
+🐶 Generated 2 files!
+
+     ✔ tmp/nest/dump.txt
+     ✔ tmp/generate.txt
+"
+`;
+
+exports[`prompt > name 2`] = `
+"a
+tmp/nest/dump.txt
+dump
+dump.txt
+.txt
+tmp/nest
+dump.txt
+
+../../snapshots/src"
+`;
+
+exports[`prompt > overwrite files 1`] = `
+"ℹ Output destination directory: \\".\\"
+
+🐶 Generated 1 file! (1 skipped)
+
+     ✔ tmp/nest/dump.txt
+     ⚠ tmp/generate.txt (skipped)
 "
 `;

--- a/packages/scaffdog/src/document.ts
+++ b/packages/scaffdog/src/document.ts
@@ -19,11 +19,24 @@ const MARKDOWN_EXTNAME = new Set([
 ]);
 
 const questionSchema = z.union([
+  // input syntax sugar
   z.string(),
+  // list, checkbox
+  z.object({
+    message: z.string(),
+    choices: z.array(z.string()),
+    multiple: z.boolean().optional(),
+    initial: z.array(z.string()).optional(),
+  }),
+  // confirm
+  z.object({
+    confirm: z.string(),
+    initial: z.boolean().optional(),
+  }),
+  // input
   z.object({
     message: z.string(),
     initial: z.string().optional(),
-    choices: z.array(z.string()).optional(),
   }),
 ]);
 

--- a/packages/scaffdog/src/prompt.ts
+++ b/packages/scaffdog/src/prompt.ts
@@ -5,9 +5,9 @@ import inquirerAutocompletePrompt from 'inquirer-autocomplete-prompt';
 
 inquirer.registerPrompt('autocomplete', inquirerAutocompletePrompt);
 
-export const prompt = async <T>(
-  question: inquirer.DistinctQuestion,
-): Promise<T> => {
+export type PromptQuestion = inquirer.DistinctQuestion;
+
+export const prompt = async <T>(question: PromptQuestion): Promise<T> => {
   const { value } = await inquirer.prompt<{ value: T }>([
     {
       ...question,
@@ -22,10 +22,11 @@ export const prompt = async <T>(
   return value;
 };
 
+export type ConfirmArgs = Omit<PromptQuestion, 'type' | 'name' | 'default'>;
 export const confirm = async (
   message: string,
   initial: boolean,
-  args: Omit<inquirer.DistinctQuestion, 'type' | 'name' | 'default'> = {},
+  args: ConfirmArgs = {},
 ): Promise<boolean> => {
   return await prompt({
     ...args,
@@ -35,10 +36,11 @@ export const confirm = async (
   });
 };
 
+export type AutocompleteArgs = Omit<PromptQuestion, 'type' | 'name'>;
 export const autocomplete = async (
   message: string,
   list: string[],
-  args: Omit<inquirer.DistinctQuestion, 'type' | 'name'> = {},
+  args: AutocompleteArgs = {},
 ): Promise<string> => {
   const fuse = new Fuse(list, {});
 


### PR DESCRIPTION
<!-- Thank you for your contribution to scaffdog! Please replace {Please write here} with your description -->

## What does this do / why do we need it?

Prompt has been added to meet the specifications of the new template engine.

```yaml
questions:
  bool:
    confirm: 'Do you need something?'
  arr:
    message: 'Please select elements.'
    multiple: true
    choices: ['A', 'B', 'C']
```

It should be useful for conditional branching and iteration :dog2: