### PR TITLE
fix(scaffdog): fix document parse bug

### DIFF
--- a/packages/scaffdog/src/document.test.ts
+++ b/packages/scaffdog/src/document.test.ts
@@ -93,6 +93,15 @@ questions:
   key4:
     message: 'message'
     choices: ['1', '2']
+  key5:
+    message: 'message'
+    choices: ['1', '2']
+    initial: '2'
+  key6:
+    message: 'message'
+    choices: ['1', '2']
+    multiple: true
+    initial: ['2']
 ---
 `.trim(),
     );
@@ -112,6 +121,17 @@ questions:
         key4: {
           message: 'message',
           choices: ['1', '2'],
+        },
+        key5: {
+          message: 'message',
+          choices: ['1', '2'],
+          initial: '2',
+        },
+        key6: {
+          message: 'message',
+          choices: ['1', '2'],
+          multiple: true,
+          initial: ['2'],
         },
       },
     });

--- a/packages/scaffdog/src/document.ts
+++ b/packages/scaffdog/src/document.ts
@@ -22,13 +22,22 @@ const MARKDOWN_EXTNAME = new Set([
 const questionSchema = z.union([
   // input syntax sugar
   z.string(),
-  // list, checkbox
+  // checkbox
   z
     .object({
       message: z.string(),
       choices: z.array(z.string()),
       multiple: z.boolean().optional(),
       initial: z.array(z.string()).optional(),
+    })
+    .strict(),
+  // list
+  z
+    .object({
+      message: z.string(),
+      choices: z.array(z.string()),
+      multiple: z.boolean().optional(),
+      initial: z.string().optional(),
     })
     .strict(),
   // confirm

--- a/website/content/docs/templates/attributes.mdx
+++ b/website/content/docs/templates/attributes.mdx
@@ -111,7 +111,7 @@ questions:
       - 'A'
       - 'B'
       - 'C'
-    initial: 'B'
+    initial: ['B']
 ```
 
 <Image src="/docs/templates/attributes/array.png" alt="array prompt" />


### PR DESCRIPTION
## How does PR fix the problem?

Fixed a bug that caused parsing errors when `initial` in list prompt was specified.

```markdown
---
questions:
  key:
    - message: 'msg'
    - choices: ['A', 'B]
    - initial: 'A' <-- Parse error
---
```
