### PR TITLE
Add conditional prompt

### DIFF
--- a/packages/@scaffdog/engine/src/helpers.test.ts
+++ b/packages/@scaffdog/engine/src/helpers.test.ts
@@ -70,6 +70,27 @@ describe('language', () => {
     ['slice - array (start x end)', `{{ seq 1 5 | slice 1 3 }}`, `2,3`],
 
     [
+      'contains - string (found)',
+      `{{ contains("foobar", "ob") ? "true" : "false" }}`,
+      `true`,
+    ],
+    [
+      'contains - string (not found)',
+      `{{ contains("foobar", "dog") ? "true" : "false" }}`,
+      `false`,
+    ],
+    [
+      'contains - array (found)',
+      `{{ contains((seq(3)), 2) ? "true" : "false" }}`,
+      `true`,
+    ],
+    [
+      'contains - array (not found)',
+      `{{ contains((seq(3)), 4) ? "true" : "false" }}`,
+      `false`,
+    ],
+
+    [
       'eval - basic',
       `{{ eval "parseInt(count5, 10) > 4 ? 'true' : 'false'" }}`,
       `true`,

--- a/packages/@scaffdog/engine/src/helpers.ts
+++ b/packages/@scaffdog/engine/src/helpers.ts
@@ -108,6 +108,24 @@ defineHelper<[v: string | any[], start: number, end?: number]>(
   },
 );
 
+defineHelper<[search: string | any[], item: any]>(
+  helpers,
+  'contains',
+  (_, search, item) => {
+    if (isString(search) || isArray(search)) {
+      return search.includes(item);
+    }
+    throw new Error(
+      `contains helper expecting string or array value but got "${typeOf(
+        search,
+      )}"`,
+    );
+  },
+  {
+    disableAutoLoop: true,
+  },
+);
+
 defineHelper<[v: string, code?: string]>(helpers, 'eval', (ctx, v, code) => {
   const evalCode = code != null ? code : v;
   const context: { [key: string]: any } = Object.create(null);

--- a/packages/scaffdog/.scaffdog/sandbox.md
+++ b/packages/scaffdog/.scaffdog/sandbox.md
@@ -1,7 +1,7 @@
 ---
 name: 'sandbox'
 root: '.'
-output: ['.', 'src/**/*']
+output: '.'
 questions:
   bool:
     confirm: 'Yes of No'
@@ -13,6 +13,9 @@ questions:
       - 'B'
       - 'C'
     initial: ['B', 'C']
+  foo:
+    if: contains(inputs.array, 'C')
+    confirm: 'message'
 ---
 
 # Variables
@@ -43,8 +46,14 @@ export default createCommand({
 });
 ```
 
-# `{{ true ? "!" : "" }}test.md`
+# `{{ true && "!" /* always skip */ }}test.md`
 
 ```markdown
-{{ inputs.array } }
+{{ inputs.array }}
+```
+
+# `{{ !inputs.foo && "!" }}foo.md`
+
+```markdown
+foo
 ```

--- a/packages/scaffdog/fixtures/question.md
+++ b/packages/scaffdog/fixtures/question.md
@@ -9,6 +9,16 @@ questions:
   input_with_initial:
     message: 'input'
     initial: 'input (initial)'
+  input_if:
+    message: 'input'
+    if: true
+  input_if_with_initial:
+    message: 'input'
+    if: false
+    initial: 'default'
+  input_if_without_initial:
+    message: 'input'
+    if: false
   bool:
     confirm: 'bool'
   bool_with_true:
@@ -17,13 +27,36 @@ questions:
   bool_with_false:
     confirm: 'bool'
     initial: false
+  bool_if:
+    confirm: 'bool'
+    if: true
+  bool_if_with_initial:
+    confirm: 'bool'
+    if: false
+    initial: true
+  bool_if_without_initial:
+    confirm: 'bool'
+    if: false
   list:
     message: 'list'
     choices: ['A', 'B', 'C']
   list_with_initial:
     message: 'list'
     choices: ['A', 'B', 'C']
-    initial: ['A', 'C']
+    initial: 'B'
+  list_if:
+    message: 'list'
+    choices: ['A', 'B', 'C']
+    if: true
+  list_if_with_initial:
+    message: 'list'
+    choices: ['A', 'B', 'C']
+    if: false
+    initial: 'B'
+  list_if_without_initial:
+    message: 'list'
+    choices: ['A', 'B', 'C']
+    if: false
   checkbox:
     message: 'checkbox'
     multiple: true
@@ -33,6 +66,22 @@ questions:
     multiple: true
     choices: ['A', 'B', 'C']
     initial: ['B', 'C']
+  checkbox_if:
+    message: 'checkbox'
+    multiple: true
+    choices: ['A', 'B', 'C']
+    if: true
+  checkbox_if_with_initial:
+    message: 'checkbox'
+    multiple: true
+    choices: ['A', 'B', 'C']
+    if: false
+    initial: ['B', 'C']
+  checkbox_if_without_initial:
+    message: 'checkbox'
+    multiple: true
+    choices: ['A', 'B', 'C']
+    if: false
 ---
 
 # `result.txt`
@@ -41,11 +90,22 @@ questions:
 shorthand: {{ inputs.shorthand }}
 input: {{ inputs.input }}
 input_with_initial: {{ inputs.input_with_initial }}
-bool: {{ inputs.bool }}
-bool_with_true: {{ inputs.bool_with_true }}
-bool_with_false: {{ inputs.bool_with_false }}
+input_if: {{ inputs.input_if }}
+input_if_with_initial: {{ inputs.input_if_with_initial }}
+input_if_without_initial: {{ inputs.input_if_without_initial }}
+bool: {{ inputs.bool ? "true" : "false" }}
+bool_with_true: {{ inputs.bool_with_true ? "true" : "false"}}
+bool_with_false: {{ inputs.bool_with_false ? "true" : "false"}}
+bool_if: {{ inputs.bool_if ? "true" : "false" }}
+bool_if_with_initial: {{ inputs.bool_if_with_initial ? "true" : "false" }}
+bool_if_without_initial: {{ inputs.bool_if_without_initial ? "true" : "false" }}
 list: {{ inputs.list }}
 list_with_initial: {{ inputs.list_with_initial }}
+list_if: {{ inputs.list_if }}
+list_if_with_initial: {{ inputs.list_if_with_initial }}
+list_if_without_initial: {{ inputs.list_if_without_initial }}
 checkbox: {{ inputs.checkbox }}
 checkbox_with_initial: {{ inputs.checkbox_with_initial }}
+checkbox_if_with_initial: {{ inputs.checkbox_if_with_initial }}
+checkbox_if_without_initial: {{ inputs.checkbox_if_without_initial }}
 ```

--- a/packages/scaffdog/src/cmds/__snapshots__/generate.test.ts.snap
+++ b/packages/scaffdog/src/cmds/__snapshots__/generate.test.ts.snap
@@ -68,13 +68,24 @@ exports[`prompt > all question types 2`] = `
 "shorthand: shorthand
 input: input
 input_with_initial: input_with_initial
-bool: bool
-bool_with_true: bool_with_true
-bool_with_false: bool_with_false
-list: list
-list_with_initial: list_with_initial
-checkbox: checkbox
-checkbox_with_initial: checkbox_with_initial"
+input_if: input_if
+input_if_with_initial: default
+input_if_without_initial: 
+bool: true
+bool_with_true: true
+bool_with_false: false
+bool_if: true
+bool_if_with_initial: true
+bool_if_without_initial: false
+list: C
+list_with_initial: B
+list_if: A
+list_if_with_initial: B
+list_if_without_initial: 
+checkbox: A,C
+checkbox_with_initial: B,C
+checkbox_if_with_initial: B,C
+checkbox_if_without_initial: "
 `;
 
 exports[`prompt > has magic and question 1`] = `

--- a/packages/scaffdog/src/cmds/generate.test.ts
+++ b/packages/scaffdog/src/cmds/generate.test.ts
@@ -110,13 +110,17 @@ describe('prompt', () => {
       .mockResolvedValueOnce('shorthand') // shorthand
       .mockResolvedValueOnce('input') // input
       .mockResolvedValueOnce('input_with_initial') // input_with_initial
-      .mockResolvedValueOnce('bool') // bool
-      .mockResolvedValueOnce('bool_with_true') // bool_with_true
-      .mockResolvedValueOnce('bool_with_false') // bool_with_false
-      .mockResolvedValueOnce('list') // list
-      .mockResolvedValueOnce('list_with_initial') // list_with_initial
-      .mockResolvedValueOnce('checkbox') // checkbox
-      .mockResolvedValueOnce('checkbox_with_initial'); // checkbox_with_initial
+      .mockResolvedValueOnce('input_if') // input_if
+      .mockResolvedValueOnce(true) // bool
+      .mockResolvedValueOnce(true) // bool_with_true
+      .mockResolvedValueOnce(false) // bool_with_false
+      .mockResolvedValueOnce(true) // bool_if
+      .mockResolvedValueOnce('C') // list
+      .mockResolvedValueOnce('B') // list_with_initial
+      .mockResolvedValueOnce('A') // list_if
+      .mockResolvedValueOnce(['A', 'C']) // checkbox
+      .mockResolvedValueOnce(['B', 'C']) // checkbox_with_initial
+      .mockResolvedValueOnce(['A']); // checkbox_if
 
     const { code, stdout, stderr } = await runCommand(cmd, {
       ...defaults,

--- a/packages/scaffdog/src/document.test.ts
+++ b/packages/scaffdog/src/document.test.ts
@@ -102,6 +102,12 @@ questions:
     choices: ['1', '2']
     multiple: true
     initial: ['2']
+  key7:
+    message: 'message'
+    if: true
+  key8:
+    message: 'message'
+    if: len(inputs.key1) > 3
 ---
 `.trim(),
     );
@@ -132,6 +138,14 @@ questions:
           choices: ['1', '2'],
           multiple: true,
           initial: ['2'],
+        },
+        key7: {
+          message: 'message',
+          if: true,
+        },
+        key8: {
+          message: 'message',
+          if: 'len(inputs.key1) > 3',
         },
       },
     });

--- a/packages/scaffdog/src/document.ts
+++ b/packages/scaffdog/src/document.ts
@@ -19,6 +19,8 @@ const MARKDOWN_EXTNAME = new Set([
   '.mkdn',
 ]);
 
+const questionIfSchema = z.union([z.boolean(), z.string()]);
+
 const questionSchema = z.union([
   // input syntax sugar
   z.string(),
@@ -29,6 +31,7 @@ const questionSchema = z.union([
       choices: z.array(z.string()),
       multiple: z.boolean().optional(),
       initial: z.array(z.string()).optional(),
+      if: questionIfSchema.optional(),
     })
     .strict(),
   // list
@@ -38,6 +41,7 @@ const questionSchema = z.union([
       choices: z.array(z.string()),
       multiple: z.boolean().optional(),
       initial: z.string().optional(),
+      if: questionIfSchema.optional(),
     })
     .strict(),
   // confirm
@@ -45,6 +49,7 @@ const questionSchema = z.union([
     .object({
       confirm: z.string(),
       initial: z.boolean().optional(),
+      if: questionIfSchema.optional(),
     })
     .strict(),
   // input
@@ -52,6 +57,7 @@ const questionSchema = z.union([
     .object({
       message: z.string(),
       initial: z.string().optional(),
+      if: questionIfSchema.optional(),
     })
     .strict(),
 ]);

--- a/website/content/docs/templates/attributes.mdx
+++ b/website/content/docs/templates/attributes.mdx
@@ -115,3 +115,20 @@ questions:
 ```
 
 <Image src="/docs/templates/attributes/array.png" alt="array prompt" />
+
+### Conditional Prompt
+
+If the result of the expression in the `if` field is `true`, Prompt is invoked. If it `false`, skip Prompt and assign initial values. The initial value is assigned to the `initial` field if it exists. If not, a zero value is assigned according to the Prompt type.
+
+```yaml
+questions:
+  name:
+    message: 'Please enter a component name.'
+
+  # Invokes confirm prompt only when input includes "Form".
+  test:
+    if: contains(inputs.name, 'Form')
+    confirm: 'Do you need a test?'
+```
+
+This is useful when you want to use a Prompt that is only needed for some use cases in the target file.

--- a/website/content/docs/templates/helpers.mdx
+++ b/website/content/docs/templates/helpers.mdx
@@ -392,6 +392,39 @@ slice(value, start, end?)
 --> 23
 ```
 
+### `contains`
+
+Searches for an item in a string or array and returns a boolean value.
+
+**Signature:**
+
+```
+contains(search, item)
+```
+
+**Paramters:**
+
+| Parameter | Type              | Description                      |
+| :-------- | :---------------- | :------------------------------- |
+| `search`  | `string \| any[]` | A string or array to search for. |
+| `item`    | `any`             | Item to search for.              |
+
+**Example:**
+
+```
+{{ contains("foo", "o") ? "true" : "false" }}
+--> true
+
+{{ contains("foo", "b") ? "true" : "false" }}
+--> false
+
+{{ contains(seq(3), 2) ? "true" : "false" }}
+--> true
+
+{{ contains(seq(3), 4) ? "true" : "false" }}
+--> false
+```
+
 ### `s2n`
 
 Converts a string to a number.

--- a/website/public/sitemap-0.xml
+++ b/website/public/sitemap-0.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://scaff.dog</loc><lastmod>2022-08-13T15:44:36.297Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://scaff.dog/playground</loc><lastmod>2022-08-13T15:44:36.297Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://scaff.dog/docs/cli</loc><lastmod>2022-08-13T15:44:36.297Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://scaff.dog/docs/config</loc><lastmod>2022-08-13T15:44:36.297Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://scaff.dog/docs</loc><lastmod>2022-08-13T15:44:36.297Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://scaff.dog/docs/integration</loc><lastmod>2022-08-13T15:44:36.297Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://scaff.dog/docs/templates/attributes</loc><lastmod>2022-08-13T15:44:36.297Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://scaff.dog/docs/templates/helpers</loc><lastmod>2022-08-13T15:44:36.297Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://scaff.dog/docs/templates</loc><lastmod>2022-08-13T15:44:36.297Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://scaff.dog/docs/templates/injection</loc><lastmod>2022-08-13T15:44:36.297Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://scaff.dog/docs/templates/template-engine</loc><lastmod>2022-08-13T15:44:36.297Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://scaff.dog/docs/templates/variables</loc><lastmod>2022-08-13T15:44:36.297Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://scaff.dog</loc><lastmod>2022-08-15T15:58:12.973Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://scaff.dog/playground</loc><lastmod>2022-08-15T15:58:12.973Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://scaff.dog/docs/cli</loc><lastmod>2022-08-15T15:58:12.973Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://scaff.dog/docs/config</loc><lastmod>2022-08-15T15:58:12.973Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://scaff.dog/docs</loc><lastmod>2022-08-15T15:58:12.973Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://scaff.dog/docs/integration</loc><lastmod>2022-08-15T15:58:12.973Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://scaff.dog/docs/templates/attributes</loc><lastmod>2022-08-15T15:58:12.973Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://scaff.dog/docs/templates/helpers</loc><lastmod>2022-08-15T15:58:12.973Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://scaff.dog/docs/templates</loc><lastmod>2022-08-15T15:58:12.973Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://scaff.dog/docs/templates/injection</loc><lastmod>2022-08-15T15:58:12.973Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://scaff.dog/docs/templates/template-engine</loc><lastmod>2022-08-15T15:58:12.973Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://scaff.dog/docs/templates/variables</loc><lastmod>2022-08-15T15:58:12.973Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>


### PR DESCRIPTION
## What does this do / why do we need it?

Added functionality for conditional branching on whether or not to invoke a prompt :dog:

````markdown
---
name: 'component'
root: '.'
output: '.'
questions:
  name: 'Please a component name.'
  test:
    if: contains(inputs.name, 'Form')
    confirm: 'Do you need a test?'
    initial: false
---

# `{{ inputs.name }}.tsx`

```typescript
// ...
```

# `{{ !inputs.test && "!" }}{{ inputs.name }}.test.tsx`

```typescript
// ...
```
````

This is a mechanism much like `if` in [GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif).