### PR TITLE
fix(scaffdog): fix a bug that `inputs` could not be referenced in the variables section

### DIFF
--- a/packages/scaffdog/.scaffdog/sandbox.md
+++ b/packages/scaffdog/.scaffdog/sandbox.md
@@ -20,6 +20,7 @@ questions:
 
 # Variables
 
+- foo: `{{ inputs.bool ? "true" : "false" }}`
 - name: `{{ "foo_bar" | kebab }}`
 
 # `{{ name }}.ts`

--- a/packages/scaffdog/fixtures/vars.md
+++ b/packages/scaffdog/fixtures/vars.md
@@ -1,0 +1,17 @@
+---
+name: 'vars'
+root: '.'
+output: '.'
+questions:
+  foo: 'message'
+---
+
+# Variables
+
+- foo: `{{ inputs.foo }}`
+
+# `tmp/index.txt`
+
+```
+foo: {{ foo }}
+```

--- a/packages/scaffdog/src/cmds/__snapshots__/generate.test.ts.snap
+++ b/packages/scaffdog/src/cmds/__snapshots__/generate.test.ts.snap
@@ -128,3 +128,14 @@ exports[`prompt > overwrite files 1`] = `
      ⚠ tmp/generate.txt (skipped)
 "
 `;
+
+exports[`prompt > variables section 1`] = `
+"ℹ Output destination directory: \\".\\"
+
+🐶 Generated 1 file!
+
+     ✔ tmp/index.txt
+"
+`;
+
+exports[`prompt > variables section 2`] = `"foo: success"`;

--- a/packages/scaffdog/src/cmds/generate.test.ts
+++ b/packages/scaffdog/src/cmds/generate.test.ts
@@ -135,6 +135,22 @@ describe('prompt', () => {
       fs.readFileSync(path.resolve(cwd, 'tmp/result.txt'), 'utf8'),
     ).toMatchSnapshot();
   });
+
+  test('variables section', async () => {
+    vi.spyOn(prompt, 'prompt').mockResolvedValueOnce('success'); // foo
+
+    const { code, stdout, stderr } = await runCommand(cmd, {
+      ...defaults,
+      name: 'vars',
+    });
+
+    expect(stderr).toBe('');
+    expect(stdout).toMatchSnapshot();
+    expect(code).toBe(0);
+    expect(
+      fs.readFileSync(path.resolve(cwd, 'tmp/index.txt'), 'utf8'),
+    ).toMatchSnapshot();
+  });
 });
 
 describe('options', () => {

--- a/packages/scaffdog/src/cmds/generate.ts
+++ b/packages/scaffdog/src/cmds/generate.ts
@@ -243,8 +243,8 @@ export default createCommand({
   logger.debug('normalized dist: %s', dist);
 
   // set variables
-  config.variables.set('cwd', cwd);
-  config.variables.set('document', {
+  context.variables.set('cwd', cwd);
+  context.variables.set('document', {
     name: doc.name,
     dir: path.dirname(doc.path),
     path: doc.path,
@@ -270,21 +270,21 @@ export default createCommand({
       }
     }
 
-    config.variables.set('inputs', inputs);
+    context.variables.set('inputs', inputs);
   } else {
-    config.variables.set('inputs', {});
+    context.variables.set('inputs', {});
   }
 
-  logger.debug('variables: %O', config.variables);
+  logger.debug('variables: %O', context.variables);
 
   // generate
   let files: File[];
   try {
     for (const [key, value] of doc.variables) {
-      config.variables.set(key, compile(value, context));
+      context.variables.set(key, compile(value, context));
     }
 
-    files = generate(doc.templates, config.variables, {
+    files = generate(doc.templates, context.variables, {
       cwd,
       root: dist,
       helpers: context.helpers,


### PR DESCRIPTION
## What does this do / why do we need it?

Bug fixes in the Variables Section.

````markdown
---
...
questions:
  name: 'msg'
---

# Variables

- name: `{{ inputs.name | pascal }}`
            ^^^^^^ <- Cannot reference

# `filename.txt`

```
{{ name }}
```
````