### PR TITLE
Remove unnecessary trimming

### DIFF
--- a/packages/@scaffdog/core/src/extract.ts
+++ b/packages/@scaffdog/core/src/extract.ts
@@ -60,7 +60,7 @@ export const extract = (input: string): ExtractResult => {
         if (filename != null) {
           templates.push({
             filename,
-            content: toString(node).trim(),
+            content: toString(node),
           });
 
           filename = null;

--- a/packages/@scaffdog/engine/src/formatter.ts
+++ b/packages/@scaffdog/engine/src/formatter.ts
@@ -82,7 +82,6 @@ const formatComment: Formatter<Comment> = (node) => {
   const lines = node.body.split('\n');
 
   if (lines.length > 1) {
-    // const body = lines.map((ln) => ln.replace(/[ \t]*$/, '')).join('\n');
     const body = lines.map((ln) => ln.trimEnd()).join('\n');
     return `/*${body}*/`;
   }


### PR DESCRIPTION
## What does this do / why do we need it?

The definition of the code block that will serve as the template is given the highest priority.

Previously, if a code block contained blank lines, it would be trimmed. This change modifies the output to take advantage of the given input as is.

## How does PR fix the problem?

Removed trim when core extracts code blocks from Markdown files.

## References

- #437
