### PR TITLE
docs: fix typo in `n2s` signature

### DIFF
--- a/website/content/docs/templates/helpers.mdx
+++ b/website/content/docs/templates/helpers.mdx
@@ -509,7 +509,7 @@ Converts a number to a string.
 **Signature:**
 
 ```
-s2n(value)
+n2s(value)
 ```
 
 **Paramters:**


### PR DESCRIPTION
<!-- Thank you for your contribution to scaffdog! Please replace {Please write here} with your description -->

## What does this do / why do we need it?

in `n2s` helper section, signature written as `s2n`

## How does PR fix the problem?

fix that (s2n -> n2s)

## What should your reviewer look out for in this PR?

## References