### PR TITLE
feat(scaffdog): add `answer` flag

### DIFF
--- a/packages/scaffdog/src/commands/__snapshots__/generate.test.ts.snap
+++ b/packages/scaffdog/src/commands/__snapshots__/generate.test.ts.snap
@@ -1,5 +1,15 @@
 // Vitest Snapshot v1
 
+exports[`args and flags > answers 1`] = `
+"ℹ Output destination directory: \\".\\"
+
+🐶 Generated 2 files!
+
+     ✔ static.txt
+     ✔ dir/.txt
+"
+`;
+
 exports[`args and flags > dry-run 1`] = `
 "ℹ Output destination directory: \\".\\"
 

--- a/packages/scaffdog/src/commands/generate.test.ts
+++ b/packages/scaffdog/src/commands/generate.test.ts
@@ -26,6 +26,7 @@ const run = (
     {
       'dry-run': false,
       force: false,
+      answer: [],
       ...flags,
     },
     lib,
@@ -308,6 +309,43 @@ describe('args and flags', () => {
     const fs = lib.resolve('fs');
     expect(fs.fileExists).not.toBeCalled();
     expect(fs.writeFile).not.toBeCalled();
+  });
+
+  test('answers', async () => {
+    const lib = createLibraryMock()
+      .provideValue(
+        'document',
+        createDocumentLibraryMock({
+          resolve: vi.fn().mockResolvedValueOnce(documents),
+        }),
+      )
+      .provideValue(
+        'question',
+        createQuestionLibraryMock({
+          resolve: vi.fn().mockResolvedValueOnce({}),
+        }),
+      );
+
+    const { code, stdout, stderr } = await run(
+      {
+        name: 'basic',
+      },
+      {
+        answer: ['key1:value', 'key2:value'],
+      },
+      lib,
+    );
+
+    expect(code).toBe(0);
+    expect(stderr).toBe('');
+    expect(stdout).toMatchSnapshot();
+
+    const question = lib.resolve('question');
+    expect(question.resolve).toBeCalledWith(
+      expect.objectContaining({
+        answers: ['key1:value', 'key2:value'],
+      }),
+    );
   });
 
   test('no documents', async () => {

--- a/packages/scaffdog/src/commands/generate.ts
+++ b/packages/scaffdog/src/commands/generate.ts
@@ -26,6 +26,13 @@ export default createCommand({
     },
   },
   flags: {
+    answer: {
+      type: 'string',
+      alias: 'a',
+      array: true,
+      description:
+        'Answer to question. The answer value is the key/value separated by ":" and can be specified multiple times.',
+    },
     'dry-run': {
       type: 'boolean',
       alias: 'n',
@@ -159,7 +166,7 @@ export default createCommand({
     const inputs = await question.resolve({
       context,
       questions: doc.questions ?? {},
-      answers: [],
+      answers: flags.answer ?? [],
     });
 
     context.variables.set('inputs', inputs);

--- a/website/content/docs/cli.mdx
+++ b/website/content/docs/cli.mdx
@@ -31,6 +31,7 @@ USAGE
   scaffdog generate <name> [flags]
 
 COMMAND FLAGS
+  -a, --answer   Answer to question. The answer value is the key/value separated by ":" and can be specified multiple times.
   -n, --dry-run  Output the result to stdout.
   -f, --force    Attempt to write the files without prompting for confirmation.
 


### PR DESCRIPTION
## What does this do / why do we need it?

Added flag to avoid `question` interaction prompts.

```bash
$ scaffdog generate component --answer "name:ScaffdogEditor"
```

