### PR TITLE
feat(scaffdog): add `output` flag

### DIFF
--- a/packages/scaffdog/src/commands/__snapshots__/generate.test.ts.snap
+++ b/packages/scaffdog/src/commands/__snapshots__/generate.test.ts.snap
@@ -54,6 +54,15 @@ exports[`args and flags > not found 1`] = `
 "
 `;
 
+exports[`args and flags > output 1`] = `
+"ℹ Output destination directory: \\"src/dir/nest\\"
+
+🐶 Generated 1 file!
+
+     ✔ src/dir/nest/file.txt
+"
+`;
+
 exports[`prompt > magic pattern and destination autocomplete 1`] = `
 "
 🐶 Generated 1 file!

--- a/website/content/docs/cli.mdx
+++ b/website/content/docs/cli.mdx
@@ -31,6 +31,7 @@ USAGE
   scaffdog generate <name> [flags]
 
 COMMAND FLAGS
+  -o, --output   Output destination directory. (Relative path from the `root` option)
   -a, --answer   Answer to question. The answer value is the key/value separated by ":" and can be specified multiple times.
   -n, --dry-run  Output the result to stdout.
   -f, --force    Attempt to write the files without prompting for confirmation.


### PR DESCRIPTION
## What does this do / why do we need it?

Added a flag to avoid prompts invoked by output destination selection.

```markdown
---
name: 'component'
root: 'src'
output: '**/*'
---
```

```bash
$ scaffdog generate component -o "icons"
// ℹ Output destination directory: "src/icons"
```