### PR TITLE
Add Node API

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,14 @@
+{
+  "mode": "pre",
+  "tag": "canary",
+  "initialVersions": {
+    "@scaffdog/config": "2.4.0",
+    "@scaffdog/core": "2.4.0",
+    "@scaffdog/engine": "2.4.0",
+    "@scaffdog/error": "2.4.0",
+    "@scaffdog/types": "2.4.0",
+    "prettier-plugin-scaffdog": "2.4.0",
+    "scaffdog": "2.4.0"
+  },
+  "changesets": []
+}

--- a/.changeset/three-pens-rhyme.md
+++ b/.changeset/three-pens-rhyme.md
@@ -1,0 +1,14 @@
+---
+'prettier-plugin-scaffdog': minor
+'@scaffdog/config': minor
+'@scaffdog/types': minor
+'scaffdog': minor
+'@scaffdog/core': minor
+'@scaffdog/engine': minor
+'@scaffdog/error': minor
+---
+
+Added two Node APIs.
+
+- `createScaffdog(options)`
+- `loadScaffdog(path, options)`

--- a/packages/@scaffdog/config/src/loader.ts
+++ b/packages/@scaffdog/config/src/loader.ts
@@ -44,28 +44,18 @@ const normalizeHelpers = (
   return map;
 };
 
-export type LoadConfigOptions = {
-  project: string;
-};
-
 export type LoadConfigResult = {
   filepath: string;
   config: ResolvedConfig;
 };
 
-export const loadConfig = (
-  cwd: string = process.cwd(),
-  options: Partial<LoadConfigOptions> = {},
-): LoadConfigResult => {
-  const opts = {
-    project: '.scaffdog',
-    ...options,
-  };
+export const loadConfig = (project?: string): LoadConfigResult => {
+  const dirname = project ?? path.resolve(process.cwd(), '.scaffdog');
 
   let filepath = '';
   let maybeConfig: unknown;
   for (const ext of extensions) {
-    filepath = path.resolve(cwd, opts.project, `config.${ext}`);
+    filepath = path.resolve(dirname, `config.${ext}`);
     if (!fileExists(filepath)) {
       continue;
     }
@@ -79,7 +69,7 @@ export const loadConfig = (
   if (maybeConfig == null) {
     const expected = `config.{${extensions.join(',')}}`;
     throw new Error(
-      `scaffdog configuration file not found (filename expected: "${expected}" in "${opts.project}")`,
+      `scaffdog configuration file not found (filename expected: "${expected}" in "${dirname}")`,
     );
   }
 

--- a/packages/prettier-plugin-scaffdog/src/index.ts
+++ b/packages/prettier-plugin-scaffdog/src/index.ts
@@ -13,8 +13,7 @@ const resolveConfig = (project: string) => {
     return configCache.get(project)!;
   }
 
-  const { dir, name } = path.parse(project);
-  const { config } = loadConfig(dir, { project: name });
+  const { config } = loadConfig(project);
 
   configCache.set(project, config);
 

--- a/packages/scaffdog/build.config.js
+++ b/packages/scaffdog/build.config.js
@@ -2,6 +2,6 @@ import config from '../../build.config';
 
 export default {
   ...config,
-  entries: ['./src/bin'],
-  declaration: false,
+  entries: ['./src/bin', './src/index'],
+  declaration: true,
 };

--- a/packages/scaffdog/package.json
+++ b/packages/scaffdog/package.json
@@ -22,6 +22,9 @@
   },
   "license": "MIT",
   "author": "wadackel <wadackel@gmail.com>",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
   "bin": {
     "scaffdog": "./dist/bin.cjs"
   },

--- a/packages/scaffdog/src/api.test.ts
+++ b/packages/scaffdog/src/api.test.ts
@@ -1,0 +1,185 @@
+import path from 'node:path';
+import { parse } from '@scaffdog/engine';
+import { describe, expect, test, vi } from 'vitest';
+import { createScaffdogInitializer } from './api';
+import { createResolvedConfig } from './lib/config.factory';
+import { createDocument } from './lib/document.factory';
+import { createDocumentLibraryMock } from './lib/document.mock';
+import { createLibraryMock } from './mocks/lib';
+import { createFile } from './file.factory';
+
+const cwd = '/path/test';
+const version = '0.0.0';
+
+describe('createScaffdog', () => {
+  test('fields', async () => {
+    const { createScaffdog } = createScaffdogInitializer({
+      version,
+      lib: createLibraryMock(),
+    });
+
+    const config = createResolvedConfig();
+
+    const scaffdog = createScaffdog({
+      filepath: path.join(cwd, '.scaffdog/config.js'),
+      config,
+      cwd,
+    });
+
+    expect(scaffdog).toEqual({
+      version,
+      path: {
+        project: path.join(cwd, '.scaffdog'),
+        config: path.join(cwd, '.scaffdog/config.js'),
+      },
+      config,
+      list: expect.any(Function),
+      generate: expect.any(Function),
+    });
+  });
+
+  test('list', async () => {
+    const documents = [
+      createDocument({
+        name: 'doc1',
+      }),
+    ];
+
+    const lib = createLibraryMock({
+      document: createDocumentLibraryMock({
+        resolve: vi.fn().mockResolvedValueOnce(documents),
+      }),
+    });
+
+    const { createScaffdog } = createScaffdogInitializer({
+      version,
+      lib,
+    });
+
+    const scaffdog = createScaffdog({
+      filepath: path.join(cwd, '.scaffdog/config.js'),
+      config: createResolvedConfig({
+        files: ['*'],
+        tags: ['<%', '%>'],
+      }),
+      cwd,
+    });
+
+    const results = await scaffdog.list();
+
+    expect(results).toEqual(documents);
+
+    expect(lib.document.resolve).toBeCalledWith(
+      path.join(cwd, '.scaffdog'),
+      ['*'],
+      {
+        tags: ['<%', '%>'],
+      },
+    );
+  });
+
+  test('generate - inputs record', async () => {
+    const { createScaffdog } = createScaffdogInitializer({
+      version,
+      lib: createLibraryMock(),
+    });
+
+    const scaffdog = createScaffdog({
+      filepath: path.join(cwd, '.scaffdog/config.js'),
+      config: createResolvedConfig(),
+      cwd,
+    });
+
+    const files = await scaffdog.generate(
+      createDocument({
+        name: 'test',
+        path: path.join(cwd, '.scaffdog/test.md'),
+        variables: new Map([['global', parse('{{ inputs.value | upper }}')]]),
+        templates: [
+          {
+            filename: parse('{{ inputs.value }}.txt'),
+            content: parse(
+              [
+                '{{ cwd }}',
+                '{{ document.path }}',
+                '{{ output.name }}',
+                '{{ output.ext }}',
+                '{{ global }}',
+              ].join('\n'),
+            ),
+          },
+          {
+            filename: parse('!skip.txt'),
+            content: parse(''),
+          },
+        ],
+      }),
+      path.join(cwd, 'dist'),
+      {
+        inputs: {
+          value: 'scaffdog',
+        },
+      },
+    );
+
+    expect(files).toEqual([
+      createFile({
+        skip: false,
+        name: 'scaffdog.txt',
+        path: path.join(cwd, 'dist/scaffdog.txt'),
+        content: [
+          cwd,
+          path.join(cwd, '.scaffdog/test.md'),
+          'scaffdog',
+          '.txt',
+          'SCAFFDOG',
+        ].join('\n'),
+      }),
+      createFile({
+        skip: true,
+        name: 'skip.txt',
+        path: path.join(cwd, 'dist/skip.txt'),
+        content: '',
+      }),
+    ]);
+  });
+
+  test('generate - inputs factory', async () => {
+    const { createScaffdog } = createScaffdogInitializer({
+      version,
+      lib: createLibraryMock(),
+    });
+
+    const scaffdog = createScaffdog({
+      filepath: path.join(cwd, '.scaffdog/config.js'),
+      config: createResolvedConfig(),
+      cwd,
+    });
+
+    const files = await scaffdog.generate(
+      createDocument({
+        name: 'test',
+        path: path.join(cwd, '.scaffdog/test.md'),
+        templates: [
+          {
+            filename: parse('{{ inputs.value }}.txt'),
+            content: parse(''),
+          },
+        ],
+      }),
+      path.join(cwd, 'dist'),
+      {
+        inputs: async () => ({ value: 'scaffdog' }),
+      },
+    );
+
+    expect(files).toEqual([
+      createFile({
+        skip: false,
+        name: 'scaffdog.txt',
+        path: path.join(cwd, 'dist/scaffdog.txt'),
+        content: '',
+      }),
+    ]);
+  });
+});

--- a/packages/scaffdog/src/api.ts
+++ b/packages/scaffdog/src/api.ts
@@ -1,0 +1,173 @@
+import { dirname, resolve } from 'path';
+import type { LoadConfigResult } from '@scaffdog/config';
+import { loadConfig } from '@scaffdog/config';
+import { compile, createContext, extendContext } from '@scaffdog/engine';
+import type { Context, ResolvedConfig, VariableRecord } from '@scaffdog/types';
+import type { File } from './file';
+import { helpers } from './helpers';
+import type { Library } from './lib';
+import type { Document } from './lib/document';
+import { assignGlobalVariables, createTemplateVariables } from './variables';
+
+/**
+ * Public API
+ */
+export type GenerateInputsResolver = (
+  context: Context,
+) => Promise<VariableRecord>;
+
+export type GenerateInputs = VariableRecord | GenerateInputsResolver;
+
+export type GenerateOptions = {
+  inputs?: GenerateInputs;
+};
+
+export type Scaffdog = {
+  version: string;
+  path: {
+    project: string;
+    config: string;
+  };
+  config: ResolvedConfig;
+  list: () => Promise<Document[]>;
+  generate: (
+    document: Document,
+    output: string,
+    options?: GenerateOptions,
+  ) => Promise<File[]>;
+};
+
+/**
+ * createScaffdog
+ */
+export type ScaffdogFactoryOptions = LoadConfigResult &
+  Partial<{
+    cwd: string;
+  }>;
+
+export type ScaffdogFactory = (options: ScaffdogFactoryOptions) => Scaffdog;
+
+/**
+ * loadScaffdog
+ */
+export type ScaffdogLoaderOptions = {
+  cwd: string;
+};
+
+export type ScaffdogLoader = (
+  path: string,
+  options?: Partial<ScaffdogLoaderOptions>,
+) => Promise<Scaffdog>;
+
+/**
+ * Initializer
+ */
+export type ScaffdogInitializerOptions = {
+  version: string;
+  lib: Library;
+};
+
+export type ScaffdogInitializer = {
+  createScaffdog: ScaffdogFactory;
+  loadScaffdog: ScaffdogLoader;
+};
+
+export const createScaffdogInitializer = ({
+  version,
+  lib,
+}: ScaffdogInitializerOptions): ScaffdogInitializer => {
+  const createScaffdog: ScaffdogInitializer['createScaffdog'] = ({
+    filepath,
+    config,
+    cwd = process.cwd(),
+  }) => ({
+    version,
+    path: {
+      project: dirname(filepath),
+      config: filepath,
+    },
+    config,
+
+    list: async () => {
+      return await lib.document.resolve(dirname(filepath), config.files, {
+        tags: config.tags,
+      });
+    },
+
+    generate: async (document, output, options = {}) => {
+      const context = createContext({
+        cwd,
+        variables: config.variables,
+        helpers: new Map([...config.helpers, ...helpers]),
+        tags: config.tags,
+      });
+
+      // set variables
+      assignGlobalVariables(context, {
+        cwd,
+        document,
+      });
+
+      // resolve inputs
+      let inputs: VariableRecord;
+      if (typeof options.inputs === 'function') {
+        inputs = await options.inputs(context);
+      } else {
+        inputs = options.inputs ?? {};
+      }
+
+      context.variables.set('inputs', inputs);
+
+      // generate
+      const files: File[] = [];
+
+      for (const [key, ast] of document.variables) {
+        context.variables.set(key, compile(ast, context));
+      }
+
+      for (const tpl of document.templates) {
+        const filename = compile(tpl.filename, context);
+        if (/^!/.test(filename)) {
+          const name = filename.slice(1);
+          files.push({
+            skip: true,
+            path: resolve(output, filename.slice(1)),
+            name,
+            content: '',
+          });
+          continue;
+        }
+
+        const ctx = extendContext(context, {
+          variables: createTemplateVariables({
+            cwd,
+            dir: output,
+            name: filename,
+          }),
+        });
+
+        files.push({
+          skip: false,
+          path: resolve(output, filename),
+          name: filename,
+          content: compile(tpl.content, ctx),
+        });
+      }
+
+      return files;
+    },
+  });
+
+  return {
+    createScaffdog,
+
+    loadScaffdog: async (path, options) => {
+      const result = loadConfig(path);
+
+      return createScaffdog({
+        ...result,
+        cwd: options?.cwd,
+      });
+    },
+  };
+};

--- a/packages/scaffdog/src/bin.ts
+++ b/packages/scaffdog/src/bin.ts
@@ -1,11 +1,15 @@
 #!/usr/bin/env node
+import { createRequire } from 'module';
 import consola, { FancyReporter } from 'consola';
 import type { PackageJson } from 'type-fest';
 import updateNotifier from 'update-notifier';
+import { createScaffdogInitializer } from './api';
 import { createCLI } from './cli';
 import { createCommandContainer } from './command-container';
 import { commands } from './commands';
 import { createLibrary } from './lib';
+
+const require = createRequire(import.meta.url);
 
 (async () => {
   const logger = consola.create({
@@ -38,7 +42,19 @@ import { createLibrary } from './lib';
 
     const container = createCommandContainer(commands);
     const lib = createLibrary(logger);
-    const cli = createCLI({ pkg, logger, container, lib });
+    const { createScaffdog: api } = createScaffdogInitializer({
+      version: pkg.version!,
+      lib,
+    });
+
+    const cli = createCLI({
+      pkg,
+      logger,
+      container,
+      lib,
+      api,
+    });
+
     const code = await cli.run(process.argv.slice(2));
 
     logger.log('');

--- a/packages/scaffdog/src/cli.test.ts
+++ b/packages/scaffdog/src/cli.test.ts
@@ -4,6 +4,7 @@ import { createCLI } from './cli';
 import type { CommandModule } from './command';
 import { createCommand } from './command';
 import { createCommandContainer } from './command-container';
+import { createScaffdogInitializerMock } from './mocks/api';
 import { createLibraryMock } from './mocks/lib';
 import { createLogger } from './mocks/logger';
 
@@ -14,6 +15,7 @@ const pkg = {
 
 describe('run', () => {
   const lib = createLibraryMock();
+  const api = createScaffdogInitializerMock().createScaffdog;
 
   const createContainer = (commands: CommandModule<any, any>[] = []) => {
     return createCommandContainer([
@@ -41,6 +43,7 @@ describe('run', () => {
       logger,
       container,
       lib,
+      api,
     });
 
     expect(await cli.run([])).toBe(0);
@@ -61,6 +64,7 @@ describe('run', () => {
       logger,
       container,
       lib,
+      api,
     });
 
     expect(await cli.run(['--help'])).toBe(0);
@@ -87,6 +91,7 @@ describe('run', () => {
       logger,
       container,
       lib,
+      api,
     });
 
     expect(await cli.run(['foo', '--help'])).toBe(0);
@@ -107,6 +112,7 @@ describe('run', () => {
       logger,
       container,
       lib,
+      api,
     });
 
     expect(await cli.run(['--version'])).toBe(0);
@@ -121,6 +127,7 @@ describe('run', () => {
       logger,
       container,
       lib,
+      api,
     });
 
     expect(await cli.run(['--verbose'])).toBe(0);
@@ -145,6 +152,7 @@ describe('run', () => {
       logger,
       container,
       lib,
+      api,
     });
 
     expect(await cli.run(['cmd'])).toBe(1234);
@@ -158,6 +166,7 @@ describe('run', () => {
       logger,
       container: createCommandContainer([]),
       lib,
+      api,
     });
 
     expect(await cli.run(['cmd'])).toBe(1);

--- a/packages/scaffdog/src/cli.ts
+++ b/packages/scaffdog/src/cli.ts
@@ -3,6 +3,7 @@ import { LogLevel } from 'consola';
 import termSize from 'term-size';
 import type { PackageJson } from 'type-fest';
 import yargs from 'yargs/yargs';
+import type { ScaffdogFactory } from './api';
 import type { CommandOption } from './command';
 import { buildCommand } from './command';
 import type { CommandContainer } from './command-container';
@@ -18,6 +19,7 @@ export type CreateCLIOptions = {
   logger: Consola;
   container: CommandContainer;
   lib: Library;
+  api: ScaffdogFactory;
 };
 
 export const createCLI = ({
@@ -25,6 +27,7 @@ export const createCLI = ({
   logger,
   container,
   lib,
+  api,
 }: CreateCLIOptions): CLI => ({
   run: async (argv) => {
     const parser = yargs()
@@ -67,6 +70,7 @@ export const createCLI = ({
       logger,
       container,
       lib,
+      api,
       size: Object.defineProperties(
         {
           rows: 0,

--- a/packages/scaffdog/src/command.ts
+++ b/packages/scaffdog/src/command.ts
@@ -1,6 +1,7 @@
 import type { Consola } from 'consola';
 import type { Merge, PackageJson } from 'type-fest';
 import type yargs from 'yargs';
+import type { ScaffdogFactory } from './api';
 import type { CommandContainer } from './command-container';
 import type { globalFlags } from './global-flags';
 import type { Library } from './lib';
@@ -24,6 +25,7 @@ export type CommandContext<A extends CommandOption, F extends CommandOption> = {
     columns: number;
   };
   lib: Library;
+  api: ScaffdogFactory;
   args: CommandArgs<A>;
   flags: GlobalFlagsWith<CommandArgs<F>>;
 };

--- a/packages/scaffdog/src/commands/generate.ts
+++ b/packages/scaffdog/src/commands/generate.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import { compile, createContext, extendContext } from '@scaffdog/engine';
 import ansiEscapes from 'ansi-escapes';
 import chalk from 'chalk';
 import globby from 'globby';
@@ -9,10 +8,14 @@ import { emojify } from 'node-emoji';
 import plur from 'plur';
 import { createCommand } from '../command';
 import type { File } from '../file';
-import { helpers } from '../helpers';
 import type { Document } from '../lib/document';
 import { formatFile } from '../utils/format';
-import { assignGlobalVariables, createTemplateVariables } from '../variables';
+
+class InputsResolverError extends Error {
+  public constructor(public parent: Error) {
+    super();
+  }
+}
 
 export default createCommand({
   name: 'generate',
@@ -55,7 +58,8 @@ export default createCommand({
   async ({
     cwd,
     logger,
-    lib: { fs, error, prompt, config, question, document },
+    lib: { fs, error, prompt, config, question },
+    api,
     size,
     args,
     flags,
@@ -68,12 +72,9 @@ export default createCommand({
       return 1;
     }
 
-    // base context
-    const context = createContext({
+    const scaffdog = api({
+      ...cfg,
       cwd,
-      variables: cfg.variables,
-      helpers: new Map([...cfg.helpers, ...helpers]),
-      tags: cfg.tags,
     });
 
     // clear
@@ -84,9 +85,7 @@ export default createCommand({
     // resolve document
     let documents: Document[];
     try {
-      documents = await document.resolve(dirname, cfg.files, {
-        tags: context.tags,
-      });
+      documents = await scaffdog.list();
     } catch (e) {
       return error.handle(e, 'Document Resolve Error');
     }
@@ -99,13 +98,12 @@ export default createCommand({
     }
 
     const name =
-      args.name == null
-        ? await prompt.prompt({
-            type: 'list',
-            message: 'Please select a document.',
-            choices: documents.map((d) => d.name),
-          })
-        : args.name;
+      args.name ??
+      (await prompt.prompt({
+        type: 'list',
+        message: 'Please select a document.',
+        choices: documents.map((d) => d.name),
+      }));
 
     logger.debug('using name: %s', name);
 
@@ -170,68 +168,40 @@ export default createCommand({
     dist = path.resolve(cwd, dist);
     logger.debug('normalized dist: %s', dist);
 
-    // set variables
-    assignGlobalVariables(context, {
-      cwd,
-      document: doc,
-    });
-
-    // inputs
-    try {
-      const inputs = await question.resolve({
-        context,
-        questions: doc.questions ?? {},
-        answers: flags.answer ?? [],
-      });
-
-      context.variables.set('inputs', inputs);
-    } catch (e) {
-      return error.handle(e, 'Question Error');
-    }
-
-    logger.debug('variables: %O', context.variables);
-
     // generate
-    const files: File[] = [];
+    let files: File[];
     try {
-      for (const [key, ast] of doc.variables) {
-        context.variables.set(key, compile(ast, context));
-      }
+      files = await scaffdog.generate(doc, dist, {
+        inputs: async (context) => {
+          try {
+            const inputs = await question.resolve({
+              context,
+              questions: doc.questions ?? {},
+              answers: flags.answer ?? [],
+            });
 
-      for (const tpl of doc.templates) {
-        const filename = compile(tpl.filename, context);
-        if (/^!/.test(filename)) {
-          const name = filename.slice(1);
-          files.push({
-            skip: true,
-            path: path.resolve(cwd, dist, name),
-            name,
-            content: '',
-          });
-          continue;
-        }
+            logger.debug(
+              'variables: %O',
+              new Map([...context.variables, ['inputs', inputs]]),
+            );
 
-        const ctx = extendContext(context, {
-          variables: createTemplateVariables({
-            cwd,
-            root: dist,
-            name: filename,
-          }),
-        });
-
-        files.push({
-          skip: false,
-          path: path.resolve(cwd, dist, filename),
-          name: filename,
-          content: compile(tpl.content, ctx),
-        });
-      }
+            return inputs;
+          } catch (e) {
+            throw new InputsResolverError(e as Error);
+          }
+        },
+      });
     } catch (e) {
-      return error.handle(e, 'Compile Error');
+      if (e instanceof InputsResolverError) {
+        return error.handle(e.parent, 'Question Error');
+      } else {
+        return error.handle(e, 'Compile Error');
+      }
     }
 
     logger.debug('files: %O', files);
 
+    // write files
     const writes: Set<File> = new Set();
     const skips: Set<File> = new Set();
 
@@ -285,6 +255,7 @@ export default createCommand({
       }
     }
 
+    // report
     const msg = {
       write: chalk.bold.green(`${writes.size} ${plur('file', writes.size)}`),
       skip: skips.size > 0 ? chalk.bold.gray(` (${skips.size} skipped)`) : '',

--- a/packages/scaffdog/src/commands/generate.ts
+++ b/packages/scaffdog/src/commands/generate.ts
@@ -62,12 +62,11 @@ export default createCommand({
   }) => {
     // configuration
     const { project } = flags;
-    const cfg = config.load(cwd, project);
+    const dirname = path.resolve(cwd, project);
+    const cfg = config.load(dirname);
     if (cfg == null) {
       return 1;
     }
-
-    const dirname = path.resolve(cwd, project);
 
     // base context
     const context = createContext({

--- a/packages/scaffdog/src/commands/list.test.ts
+++ b/packages/scaffdog/src/commands/list.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test, vi } from 'vitest';
 import { createResolvedConfig } from '../lib/config.factory';
 import { createConfigLibraryMock } from '../lib/config.mock';
 import { createDocument } from '../lib/document.factory';
-import { createDocumentLibraryMock } from '../lib/document.mock';
+import { createScaffdogMock } from '../mocks/api';
 import { createCommandRunner, cwd } from '../mocks/command-test-utils';
 import { createLibraryMock } from '../mocks/lib';
 import cmd from './list';
@@ -69,26 +69,22 @@ test('success', async () => {
 
   const lib = createLibraryMock({
     config,
-    document: createDocumentLibraryMock({
-      resolve: vi.fn().mockResolvedValueOnce(documents),
-    }),
+  });
+
+  const scaffdog = createScaffdogMock({
+    list: vi.fn().mockResolvedValueOnce(documents),
   });
 
   const { code, stdout, stderr } = await run({
     lib,
+    api: vi.fn().mockReturnValueOnce(scaffdog),
   });
 
   expect(code).toBe(0);
   expect(stderr).toBe('');
   expect(stdout).toMatchSnapshot();
 
-  expect(lib.document.resolve).toBeCalledWith(
-    path.resolve(cwd, '.scaffdog'),
-    ['*'],
-    {
-      tags: ['{{', '}}'],
-    },
-  );
+  expect(scaffdog.list).toBeCalledWith();
 });
 
 describe('failure', () => {
@@ -111,13 +107,15 @@ describe('failure', () => {
   test('document not found', async () => {
     const lib = createLibraryMock({
       config,
-      document: createDocumentLibraryMock({
-        resolve: vi.fn().mockResolvedValueOnce([]),
-      }),
+    });
+
+    const scaffdog = createScaffdogMock({
+      list: vi.fn().mockResolvedValueOnce([]),
     });
 
     const { code, stdout, stderr } = await run({
       lib,
+      api: vi.fn().mockReturnValueOnce(scaffdog),
     });
 
     expect(code).toBe(1);

--- a/packages/scaffdog/src/commands/list.ts
+++ b/packages/scaffdog/src/commands/list.ts
@@ -12,12 +12,12 @@ export default createCommand({
   flags: {},
 })(async ({ cwd, logger, lib: { config, document }, flags }) => {
   const { project } = flags;
-  const cfg = config.load(cwd, project);
+  const dirname = path.resolve(cwd, project);
+  const cfg = config.load(dirname);
   if (cfg == null) {
     return 1;
   }
 
-  const dirname = path.resolve(cwd, project);
   const documents = await document.resolve(dirname, cfg.files, {
     tags: cfg.tags,
   });

--- a/packages/scaffdog/src/commands/list.ts
+++ b/packages/scaffdog/src/commands/list.ts
@@ -10,7 +10,7 @@ export default createCommand({
   summary: 'Print a list of available documents.',
   args: {},
   flags: {},
-})(async ({ cwd, logger, lib: { config, document }, flags }) => {
+})(async ({ cwd, logger, lib: { config }, api, flags }) => {
   const { project } = flags;
   const dirname = path.resolve(cwd, project);
   const cfg = config.load(dirname);
@@ -18,9 +18,12 @@ export default createCommand({
     return 1;
   }
 
-  const documents = await document.resolve(dirname, cfg.files, {
-    tags: cfg.tags,
+  const scaffdog = api({
+    ...cfg,
+    cwd,
   });
+
+  const documents = await scaffdog.list();
 
   if (documents.length === 0) {
     logger.warn('Document file not found.');

--- a/packages/scaffdog/src/file.factory.ts
+++ b/packages/scaffdog/src/file.factory.ts
@@ -1,0 +1,18 @@
+import merge from 'deepmerge';
+import { isPlainObject } from 'is-plain-object';
+import type { PartialDeep } from 'type-fest';
+import type { File } from './file';
+
+export const createFile = (props: PartialDeep<File> = {}): File =>
+  merge(
+    {
+      skip: false,
+      path: '',
+      name: '',
+      content: '',
+    },
+    props as any,
+    {
+      isMergeableObject: isPlainObject,
+    },
+  );

--- a/packages/scaffdog/src/index.ts
+++ b/packages/scaffdog/src/index.ts
@@ -1,0 +1,44 @@
+import { createRequire } from 'module';
+import consola, { LogLevel } from 'consola';
+import type { PackageJson } from 'type-fest';
+import { createScaffdogInitializer } from './api';
+import { createLibrary } from './lib';
+
+const require = createRequire(import.meta.url);
+const pkg = require('../package.json') as PackageJson;
+
+/**
+ * Export types
+ */
+export type { LoadConfigResult } from '@scaffdog/config';
+export type { Context, ResolvedConfig, VariableRecord } from '@scaffdog/types';
+export type {
+  GenerateInputs,
+  GenerateInputsResolver,
+  GenerateOptions,
+  Scaffdog,
+  ScaffdogFactory,
+  ScaffdogFactoryOptions,
+  ScaffdogLoader,
+  ScaffdogLoaderOptions,
+} from './api';
+export type { File } from './file';
+export type { Document } from './lib/document';
+
+/**
+ * Export initializer
+ */
+const logger = consola.create({
+  level: LogLevel.Silent,
+  reporters: [],
+});
+
+const lib = createLibrary(logger);
+
+const initializer = createScaffdogInitializer({
+  version: pkg.version!,
+  lib,
+});
+
+export const createScaffdog = initializer.createScaffdog;
+export const loadScaffdog = initializer.loadScaffdog;

--- a/packages/scaffdog/src/lib/config.ts
+++ b/packages/scaffdog/src/lib/config.ts
@@ -1,10 +1,10 @@
+import type { LoadConfigResult } from '@scaffdog/config';
 import { loadConfig } from '@scaffdog/config';
-import type { ResolvedConfig } from '@scaffdog/types';
 import type { Consola } from 'consola';
 import type { ErrorLibrary } from './error';
 
 export type ConfigLibrary = {
-  load: (project: string) => ResolvedConfig | null;
+  load: (project: string) => LoadConfigResult | null;
 };
 
 export const createConfigLibrary = (
@@ -13,10 +13,10 @@ export const createConfigLibrary = (
 ): ConfigLibrary => ({
   load: (project) => {
     try {
-      const { filepath, config } = loadConfig(project);
-      logger.debug('loaded config path: %s', filepath);
-      logger.debug('loaded config: %O', config);
-      return config;
+      const result = loadConfig(project);
+      logger.debug('loaded config path: %s', result.filepath);
+      logger.debug('loaded config: %O', result.config);
+      return result;
     } catch (e) {
       error.handle(e, 'Load Config Error');
       return null;

--- a/packages/scaffdog/src/lib/config.ts
+++ b/packages/scaffdog/src/lib/config.ts
@@ -4,16 +4,16 @@ import type { Consola } from 'consola';
 import type { ErrorLibrary } from './error';
 
 export type ConfigLibrary = {
-  load: (cwd: string, project: string) => ResolvedConfig | null;
+  load: (project: string) => ResolvedConfig | null;
 };
 
 export const createConfigLibrary = (
   logger: Consola,
   error: ErrorLibrary,
 ): ConfigLibrary => ({
-  load: (cwd, project) => {
+  load: (project) => {
     try {
-      const { filepath, config } = loadConfig(cwd, { project });
+      const { filepath, config } = loadConfig(project);
       logger.debug('loaded config path: %s', filepath);
       logger.debug('loaded config: %O', config);
       return config;

--- a/packages/scaffdog/src/mocks/api.ts
+++ b/packages/scaffdog/src/mocks/api.ts
@@ -1,0 +1,29 @@
+import { vi } from 'vitest';
+import type { Scaffdog, ScaffdogInitializer } from '../api';
+import { createResolvedConfig } from '../lib/config.factory';
+
+export const createScaffdogMock = (
+  mocks: Partial<Scaffdog> = {},
+): Scaffdog => ({
+  version: '',
+  path: {
+    project: '',
+    config: '',
+  },
+  config: createResolvedConfig(),
+  list: vi.fn(),
+  generate: vi.fn(),
+  ...mocks,
+});
+
+export const createScaffdogInitializerMock = (
+  mocks: Partial<ScaffdogInitializer> = {},
+): ScaffdogInitializer => {
+  const scaffdog = createScaffdogMock();
+
+  return {
+    createScaffdog: vi.fn().mockReturnValueOnce(scaffdog),
+    loadScaffdog: vi.fn().mockResolvedValueOnce(scaffdog),
+    ...mocks,
+  };
+};

--- a/packages/scaffdog/src/mocks/command-test-utils.ts
+++ b/packages/scaffdog/src/mocks/command-test-utils.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import type { ScaffdogFactory } from '../api';
 import type {
   AnyCommandModule,
   CommandArgs,
@@ -12,6 +13,7 @@ import type {
 import type { CommandContainer } from '../command-container';
 import { createCommandContainer } from '../command-container';
 import type { Library } from '../lib';
+import { createScaffdogInitializerMock } from './api';
 import { createLibraryMock } from './lib';
 import { createLogger } from './logger';
 
@@ -21,6 +23,7 @@ export type CommandRunnerParams<T extends AnyCommandModule> = {
   args?: Partial<CommandArgs<InferredCommandModuleArgs<T>>>;
   flags?: Partial<GlobalFlagsWith<CommandArgs<InferredCommandModuleFlags<T>>>>;
   lib?: Library;
+  api?: ScaffdogFactory;
   container?: CommandContainer;
 };
 
@@ -40,7 +43,7 @@ export const createCommandRunner =
       flags: CommandArgs<F>;
     },
   ): CommandRunner<CommandModule<A, F>> =>
-  async ({ args, flags, lib, container }) => {
+  async ({ args, flags, lib, api, container }) => {
     const { logger, getStdout, getStderr } = createLogger();
 
     const globalFlags: GlobalFlags = {
@@ -64,6 +67,7 @@ export const createCommandRunner =
       logger,
       container: container ?? createCommandContainer([]),
       lib: lib ?? createLibraryMock({}),
+      api: api ?? createScaffdogInitializerMock({}).createScaffdog,
       args: {
         ...defaults.args,
         ...(args ?? {}),

--- a/packages/scaffdog/src/variables.ts
+++ b/packages/scaffdog/src/variables.ts
@@ -22,31 +22,33 @@ export const assignGlobalVariables = (
 
 export type CreateTemplateVariablesOptions = {
   cwd: string;
-  root: string;
+  dir: string;
   name: string;
 };
 
 export const createTemplateVariables = ({
   cwd,
-  root,
+  dir,
   name,
 }: CreateTemplateVariablesOptions): VariableMap => {
-  const variables: VariableMap = new Map();
-
-  const absolute = path.resolve(cwd, root, name);
+  const absolute = path.resolve(dir, name);
   const relative = path.relative(cwd, absolute);
   const info = path.parse(relative);
 
-  variables.set('cwd', cwd);
-  variables.set('output', {
-    root,
-    path: relative,
-    abs: absolute,
-    name: info.name,
-    base: info.base,
-    ext: info.ext,
-    dir: info.dir,
-  });
+  const variables: VariableMap = new Map([
+    [
+      'output',
+      {
+        root: info.dir /** @deprecated Use `output.dir` instead of `output.root` */,
+        path: relative,
+        abs: absolute,
+        name: info.name,
+        base: info.base,
+        ext: info.ext,
+        dir: info.dir,
+      },
+    ],
+  ]);
 
   return variables;
 };

--- a/packages/scaffdog/test/__snapshots__/e2e.test.ts.snap
+++ b/packages/scaffdog/test/__snapshots__/e2e.test.ts.snap
@@ -11,6 +11,8 @@ exports[`generate > failure - inputs (.) 1`] = `
   {stacktrace}
   {stacktrace}
   {stacktrace}
+  {stacktrace}
+  {stacktrace}
 
 
 
@@ -23,6 +25,8 @@ exports[`generate > failure - inputs (.) 2`] = `
 
  ERROR  Question Error: \\"choice\\" must be one of \\"A, B, C\\"
 
+  {stacktrace}
+  {stacktrace}
   {stacktrace}
   {stacktrace}
   {stacktrace}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2018",
-    "module": "commonjs",
+    "target": "es2018",
+    "module": "esnext",
+    "moduleResolution": "node",
     "declaration": true,
     "pretty": true,
     "importHelpers": false,

--- a/website/content/docs/api.mdx
+++ b/website/content/docs/api.mdx
@@ -1,0 +1,109 @@
+---
+title: 'API'
+description: 'This section describes the Node API provided by scaffdog.'
+---
+
+Besides being used as a CLI tool, scaffdog provides a high-level API for Node.js.  
+See this page on using scaffdog programmatically.
+
+## `createScaffdog(options)`
+
+Factory function of a [Scaffdog](#scaffdog) object. Usually initialised using the result of reading using the [@scaffdog/config](https://github.com/scaffdog/scaffdog/tree/canary/packages/%40scaffdog/config) package.
+
+**Parameters:**
+
+- `options.filepath`: `string`
+- `options.config`: [`ResolvedConfig`](https://github.com/scaffdog/scaffdog/blob/canary/packages/%40scaffdog/types/src/config.ts#L13-L19)
+- `options.cwd?`: `string`
+
+**Return:**
+
+- [`Scaffdog`](#scaffdog)
+
+```typescript
+import { loadConfig } from '@scaffdog/config';
+import { createScaffdog } from 'scaffdog';
+
+const descriptor = loadConfig(project);
+const scaffdog = createScaffdog(descriptor);
+```
+
+## `loadScaffdog(path, options)`
+
+Finds the scaffdog project in the specified directory and returns a [Scaffdog](#scaffdog) object.  
+If no configuration file is found and the scaffdog project is deemed invalid, a rejected Promise is returned.
+
+**Parameters:**
+
+- `path`: `string`
+- `options.cwd?`: `string`
+
+**Return:**
+
+- [`Promise<Scaffdog>`](#scaffdog)
+
+```typescript
+import { loadScaffdog } from 'scaffdog';
+
+const scaffdog = await loadScaffdog();
+```
+
+## `Scaffdog`
+
+An object that holds information about the scaffdog project and provides the central API for the scaffdog.
+
+### `scaffdog.list()`
+
+Returns a list of documents corresponding to [files](./config#simple-configuration) in the configuration file.
+
+**Return:**
+
+- `Promise<Document[]>`
+
+```typescript
+const documents = await scaffdog.list();
+const document = documents.find((d) => d.name === 'component');
+```
+
+### `scaffdog.generate(document, output, options)`
+
+Specify the document object and output directory and compile each template. No file generation is actually performed.
+
+**Parameters:**
+
+- `document`: `Document`
+- `output`: `string`
+- `options.inputs?`: `VariableRecord | GenerateInputsResolver`
+
+**Return:**
+
+- `Promise<File[]>`
+
+```typescript
+import fs from 'node:fs/promises';
+
+const [document] = await scaffdog.list();
+
+// Using object inputs
+const files = await scaffdog.generate(document, '/path/to/dist', {
+  inputs: {
+    name: 'FooComponent',
+  },
+});
+
+for (const file of files) {
+  if (file.skip) {
+    continue;
+  }
+  await fs.writeFile(file.path, file.content);
+}
+
+// Using inputs factory
+// const files = await scaffdog.generate(document, '/path/to/dist', {
+//   inputs: async (context) => {
+//     return {
+//       name: 'FooComponent',
+//     };
+//   },
+// });
+```

--- a/website/routing/sidebar.ts
+++ b/website/routing/sidebar.ts
@@ -40,6 +40,10 @@ export const sidebar: RouteItem[] = [
     path: '/docs/cli',
   },
   {
+    title: 'API',
+    path: '/docs/api',
+  },
+  {
     title: 'Integration',
     path: '/docs/integration',
   },


### PR DESCRIPTION
## What does this do / why do we need it?

Added two Node APIs.

- `createScaffdog(options)`
- `loadScaffdog(path, options)`

It is a useful API for the programmatic use of scaffdog.

## How does PR fix the problem?

n/a

## What should your reviewer look out for in this PR?

n/a

## References

- n/a
