### PR TITLE
fix(scaffdog): add missing exports

### DIFF
--- a/.changeset/stupid-socks-jog.md
+++ b/.changeset/stupid-socks-jog.md
@@ -1,0 +1,9 @@
+---
+'scaffdog': patch
+---
+
+Add missing exports.
+
+- `Variable`
+- `Question*`
+- `DocumentAttributes`

--- a/packages/scaffdog/src/index.ts
+++ b/packages/scaffdog/src/index.ts
@@ -11,7 +11,12 @@ const pkg = require('../package.json') as PackageJson;
  * Export types
  */
 export type { LoadConfigResult } from '@scaffdog/config';
-export type { Context, ResolvedConfig, VariableRecord } from '@scaffdog/types';
+export type {
+  Context,
+  ResolvedConfig,
+  VariableRecord,
+  Variable,
+} from '@scaffdog/types';
 export type {
   GenerateInputs,
   GenerateInputsResolver,
@@ -23,7 +28,15 @@ export type {
   ScaffdogLoaderOptions,
 } from './api';
 export type { File } from './file';
-export type { Document } from './lib/document';
+export type {
+  QuestionCheckbox,
+  QuestionList,
+  QuestionConfirm,
+  QuestionInput,
+  Question,
+  QuestionMap,
+} from './lib/question';
+export type { Document, DocumentAttributes } from './lib/document';
 
 /**
  * Export initializer


### PR DESCRIPTION
## What does this do / why do we need it?

Add missing exports.

- `Variable`
- `Question*`
- `DocumentAttributes`

## How does PR fix the problem?

n/a

## What should your reviewer look out for in this PR?

n/a

## References

- n/a
