### PR TITLE
fix(error): fix error report when a blank line is included

### DIFF
--- a/.changeset/spotty-windows-sip.md
+++ b/.changeset/spotty-windows-sip.md
@@ -1,0 +1,5 @@
+---
+'@scaffdog/error': patch
+---
+
+Fixed an error report when a template with a blank line contains invalid syntax.

--- a/packages/@scaffdog/error/src/index.test.ts
+++ b/packages/@scaffdog/error/src/index.test.ts
@@ -64,16 +64,17 @@ test('multi line', () => {
 3
 4
 5
+
 6 error! after text
 7
 8`,
-    range: [12, 17],
+    range: [13, 18],
   });
 
   expect(e.format({ ...defaults })).toBe(`   ${errorMessage}
 
- ${s} ${l} 4
  ${s} ${l} 5
+ ${s} ${l} 
  ${r} ${l} 6 ${red('error!')} after text
  ${s} ${l}   ${red('^^^^^^')}
  ${s} ${l} 7

--- a/packages/@scaffdog/error/src/scaffdog-error.ts
+++ b/packages/@scaffdog/error/src/scaffdog-error.ts
@@ -54,22 +54,16 @@ const extractLines = (
 ): string[] => {
   const lines: string[] = [];
   const buffer: string[] = [];
-  const terminator: string[] = [];
   let line = 1;
 
   for (const s of source) {
     if (NEWLINE.test(s)) {
-      terminator.push(s);
-      continue;
-    }
-
-    if (terminator.length > 0) {
       if (line >= start) {
         lines.push(buffer.join(''));
       }
       buffer.length = 0;
-      terminator.length = 0;
       line++;
+      continue;
     }
 
     buffer.push(s);


### PR DESCRIPTION
<!-- Thank you for your contribution to scaffdog! Please replace {Please write here} with your description -->

## What does this do / why do we need it?

Fixed an error report when a template with a blank line contains invalid syntax.

## How does PR fix the problem?

n/a

## What should your reviewer look out for in this PR?

n/a

## References

- n/a
