### PR TITLE
Remove `safe-eval` and use the `vm` module instead

### DIFF
--- a/.changeset/eighty-cameras-walk.md
+++ b/.changeset/eighty-cameras-walk.md
@@ -1,0 +1,10 @@
+---
+'@scaffdog/engine': patch
+'scaffdog': patch
+---
+
+Fixes for `safe-eval` vulnerability issues.
+Fixes to remove `safe-eval` as a dependency and use `vm.runInNewContext` instead.
+Since scaffdog is intended to be used in a development environment, it is assumed that the input code is safe. Do not use the `eval` helper function in situations where it receives input from third parties.
+
+Fixes: #766

--- a/packages/@scaffdog/engine/package.json
+++ b/packages/@scaffdog/engine/package.json
@@ -34,8 +34,7 @@
     "change-case": "^4.1.2",
     "dayjs": "^1.10.4",
     "is-plain-object": "^5.0.0",
-    "plur": "4.0.0",
-    "safe-eval": "^0.4.1"
+    "plur": "4.0.0"
   },
   "devDependencies": {
     "@unicode/unicode-15.0.0": "1.3.1",

--- a/packages/@scaffdog/engine/src/helpers.test.ts
+++ b/packages/@scaffdog/engine/src/helpers.test.ts
@@ -102,19 +102,6 @@ describe('language', () => {
       `{{ contains((seq(3)), 4) ? "true" : "false" }}`,
       `false`,
     ],
-
-    [
-      'eval - basic',
-      `{{ eval "parseInt(count5, 10) > 4 ? 'true' : 'false'" }}`,
-      `true`,
-    ],
-    ['eval - chain', `{{ "foo" | eval "parseInt(count5, 10) + 5" }}`, `10`],
-    ['eval - chain', `{{ "foo" | eval "parseInt(count5, 10) + 5" }}`, `10`],
-    [
-      'eval - array',
-      `{{ eval ("parseInt(count5,10)+1 / parseInt(count5,10)+2 / parseInt(count5,10)+3" | split "/") }}`,
-      `6,7,8`,
-    ],
   ])('%s', (_, source, expected) => {
     expect(compile(parse(source, { tags: context.tags }), context)).toBe(
       expected,

--- a/packages/@scaffdog/engine/src/helpers.ts
+++ b/packages/@scaffdog/engine/src/helpers.ts
@@ -2,7 +2,6 @@ import type { HelperMap, Variable } from '@scaffdog/types';
 import * as cc from 'change-case';
 import plur from 'plur';
 import dayjs from 'dayjs';
-import safeEval from 'safe-eval';
 import { defineHelper } from './helper-utils';
 import { isArray, isString, isNumber, isObject, typeOf } from './utils';
 
@@ -144,17 +143,6 @@ defineHelper<[search: string | any[], item: any]>(
     disableAutoLoop: true,
   },
 );
-
-defineHelper<[v: string, code?: string]>(helpers, 'eval', (ctx, v, code) => {
-  const evalCode = code != null ? code : v;
-  const context: { [key: string]: any } = Object.create(null);
-
-  for (const [key, value] of ctx.variables.entries()) {
-    context[key] = value;
-  }
-
-  return safeEval(evalCode, context);
-});
 
 /**
  * string utils

--- a/packages/scaffdog/src/helpers.test.ts
+++ b/packages/scaffdog/src/helpers.test.ts
@@ -1,0 +1,27 @@
+import { compile, createContext, extendContext, parse } from '@scaffdog/engine';
+import type { Variable } from '@scaffdog/types';
+import { expect, test } from 'vitest';
+import { helpers } from './helpers';
+
+const context = createContext({
+  helpers,
+});
+
+test.each([
+  ['basic', `{{ eval "parseInt(cnt, 10) > 4 ? 'true' : 'false'" }}`, `true`],
+  ['chain', `{{ "foo" | eval "parseInt(cnt, 10) + 5" }}`, `10`],
+  [
+    'array',
+    `{{ eval ("parseInt(cnt,10)+1 / parseInt(cnt,10)+2 / parseInt(cnt,10)+3" | split "/") }}`,
+    `6,7,8`,
+  ],
+])('eval - %s', (_, source, expected) => {
+  expect(
+    compile(
+      parse(source, { tags: context.tags }),
+      extendContext(context, {
+        variables: new Map<string, Variable>([['cnt', 5]]),
+      }),
+    ),
+  ).toBe(expected);
+});

--- a/packages/scaffdog/src/helpers.ts
+++ b/packages/scaffdog/src/helpers.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import vm from 'vm';
 import { defineHelper, extendContext, render } from '@scaffdog/engine';
 import type { HelperMap, Variable } from '@scaffdog/types';
 import { isPlainObject } from 'is-plain-object';
@@ -13,6 +14,17 @@ const isObjectVariable = (
 };
 
 export const helpers: HelperMap = new Map();
+
+defineHelper<[v: string, code?: string]>(helpers, 'eval', (ctx, v, code) => {
+  const evalCode = code != null ? code : v;
+  const context: Record<string, unknown> = Object.create(null);
+
+  for (const [key, value] of ctx.variables.entries()) {
+    context[key] = value;
+  }
+
+  return vm.runInNewContext(evalCode, context);
+});
 
 defineHelper<string[]>(
   helpers,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,7 +102,6 @@ importers:
       is-plain-object: ^5.0.0
       plur: 4.0.0
       regenerate: 1.4.2
-      safe-eval: ^0.4.1
     dependencies:
       '@scaffdog/error': link:../error
       '@scaffdog/types': link:../types
@@ -110,7 +109,6 @@ importers:
       dayjs: 1.11.4
       is-plain-object: 5.0.0
       plur: 4.0.0
-      safe-eval: 0.4.1
     devDependencies:
       '@unicode/unicode-15.0.0': 1.3.1
       regenerate: 1.4.2
@@ -269,6 +267,7 @@ importers:
       remark-emoji: ^3.0.2
       remark-gfm: ^3.0.1
       remark-slug: ^7.0.1
+      shadowrealm-api: ^0.8.2
       type-fest: 3.5.0
       typescript: 5.1.3
       yup: ^1.0.0
@@ -300,6 +299,7 @@ importers:
       remark-emoji: 3.0.2
       remark-gfm: 3.0.1
       remark-slug: 7.0.1
+      shadowrealm-api: 0.8.2
       yup: 1.2.0
     devDependencies:
       '@babel/core': 7.22.5
@@ -9925,10 +9925,6 @@ packages:
   /safe-buffer/5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
-  /safe-eval/0.4.1:
-    resolution: {integrity: sha512-wmiu4RSYVZ690RP1+cv/LxfPK1dIlEN35aW7iv4SMYdqDrHbkll4+NJcHmKm7PbCuI1df1otOcPwgcc2iFR85g==}
-    dev: false
-
   /safe-regex-test/1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
     dependencies:
@@ -10007,6 +10003,10 @@ packages:
   /set-blocking/2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
     dev: true
+
+  /shadowrealm-api/0.8.2:
+    resolution: {integrity: sha512-JJvmduce8QhsyCnabM7Fm+FzEeubuuARCe/iJcSqzdzRKISeQjCvMKFIrbt4ATEIWuFF00mU2uTKG76Ifc1xOQ==}
+    dev: false
 
   /shebang-command/1.2.0:
     resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}

--- a/website/app/playground/Playground.tsx
+++ b/website/app/playground/Playground.tsx
@@ -1,14 +1,19 @@
 'use client';
 
 import { Box, Flex } from '@chakra-ui/react';
-import type { NextPage } from 'next';
 import { RecoilRoot } from 'recoil';
+import { useLayoutEffect } from 'react';
 import { PlaygroundFooter } from './PlaygroundFooter';
 import { PlaygroundHeader } from './PlaygroundHeader';
 import { PlaygroundPreview } from './PlaygroundPreview';
 import { PlaygroundTab } from './PlaygroundTab';
 
-export const Playground: NextPage = () => {
+export const Playground: React.FC = () => {
+  useLayoutEffect(() => {
+    // eslint-disable-next-line no-console
+    import('shadowrealm-api/dist/polyfill').catch(console.warn);
+  }, []);
+
   return (
     <RecoilRoot>
       <Flex direction="column" h={{ base: 'auto', md: '100vh' }}>

--- a/website/app/playground/PlaygroundPreview.tsx
+++ b/website/app/playground/PlaygroundPreview.tsx
@@ -33,7 +33,7 @@ export const _Highlight: React.FC<{ code: string; language: string }> = ({
               <chakra.div key={i} display="table-row" px="2">
                 <chakra.span display="table-cell">
                   {line.map((token, key) => (
-                    <span key={key} {...getTokenProps({ token, key })} />
+                    <span key={key} {...getTokenProps({ token })} />
                   ))}
                 </chakra.span>
               </chakra.div>

--- a/website/package.json
+++ b/website/package.json
@@ -36,6 +36,7 @@
     "remark-emoji": "^3.0.2",
     "remark-gfm": "^3.0.1",
     "remark-slug": "^7.0.1",
+    "shadowrealm-api": "^0.8.2",
     "yup": "^1.0.0"
   },
   "devDependencies": {

--- a/website/utils/scaffdog.ts
+++ b/website/utils/scaffdog.ts
@@ -1,0 +1,112 @@
+import path from 'path';
+import { extract } from '@scaffdog/core';
+import type { HelperMap, Variable } from '@scaffdog/types';
+import {
+  compile as engineCompile,
+  createContext,
+  extendContext,
+  defineHelper,
+} from '@scaffdog/engine';
+
+type ShadowRealmConstructor = {
+  new (): ShadowRealm;
+};
+
+type Primitive = undefined | null | boolean | number | string;
+
+type Callable = Function; // eslint-disable-line @typescript-eslint/ban-types
+
+export type ShadowRealm = {
+  evaluate: (sourceText: string) => Primitive | Callable;
+  importValue: (
+    specifier: string,
+    bindingName: string,
+  ) => Promise<Primitive | Callable>;
+};
+
+const helpers: HelperMap = new Map();
+
+defineHelper<[v: string, code?: string]>(helpers, 'eval', (ctx, v, code) => {
+  const ShadowRealm = (globalThis as any).ShadowRealm as
+    | ShadowRealmConstructor
+    | undefined;
+  if (ShadowRealm == null) {
+    throw new Error('Running `eval` requires `ShadowRealm` support.');
+  }
+
+  const evalCode = code != null ? code : v;
+  const realm = new ShadowRealm();
+  const vars = Array.from(ctx.variables.entries())
+    .map(([key, value]) => `let ${key} = ${JSON.stringify(value)};`)
+    .join('\n');
+
+  return String(realm.evaluate(`${vars}\n${evalCode}`));
+});
+
+export type File = {
+  skip: boolean;
+  path: string;
+  content: string;
+};
+
+export const compile = (
+  source: string,
+  inputs: Record<string, Variable>,
+): File[] => {
+  const { variables, templates } = extract(source, {});
+  const cwd = '/workspace';
+  const context = createContext({
+    cwd,
+    helpers,
+  });
+
+  context.variables.set('cwd', cwd);
+  context.variables.set('inputs', inputs);
+  context.variables.set('document', {
+    name: 'playground.md',
+    dir: '.scaffdog',
+    path: path.join(cwd, '.scaffdog'),
+  });
+
+  for (const [key, ast] of variables) {
+    context.variables.set(key, engineCompile(ast, context));
+  }
+
+  return templates.map((tpl) => {
+    const filename = engineCompile(tpl.filename, context);
+    if (/^!/.test(filename)) {
+      return {
+        skip: true,
+        path: path.resolve(cwd, filename.slice(1)),
+        content: '',
+      };
+    }
+
+    const absolute = path.resolve(cwd, filename);
+    const relative = path.relative(cwd, absolute);
+    const info = path.parse(relative);
+
+    const ctx = extendContext(context, {
+      variables: new Map([
+        [
+          'output',
+          {
+            root: '.',
+            path: filename,
+            abs: absolute,
+            name: info.name,
+            base: info.base,
+            ext: info.ext,
+            dir: info.dir,
+          },
+        ],
+      ]),
+    });
+
+    return {
+      skip: false,
+      path: filename,
+      content: engineCompile(tpl.content, ctx),
+    };
+  });
+};


### PR DESCRIPTION
<!-- Thank you for your contribution to scaffdog! Please replace {Please write here} with your description -->

## What does this do / why do we need it?

Fixes for `safe-eval` vulnerability issues.
Fixes to remove `safe-eval` as a dependency and use `vm.runInNewContext` instead.
Since scaffdog is intended to be used in a development environment, it is assumed that the input code is safe. Do not use the `eval` helper function in situations where it receives input from third parties.

## How does PR fix the problem?

- See References section.

## What should your reviewer look out for in this PR?

n/a

## References

- #766
