### PR TITLE
docs: fix output attribute to be able to accept array string

### DIFF
--- a/website/content/docs/templates/attributes.mdx
+++ b/website/content/docs/templates/attributes.mdx
@@ -9,13 +9,13 @@ The meta of a template document is called Attributes. Several options can be com
 
 List of attributes that can be specified with Front Matter.
 
-| key                      | type       | description                                                                                                                       |
-| :----------------------- | :--------- | :-------------------------------------------------------------------------------------------------------------------------------- |
-| `name`<br />(required)   | `string`   | Name of template.                                                                                                                 |
-| `root`<br />(required)   | `string`   | The directory as the starting point of the output destination.                                                                    |
-| `output`<br />(required) | `string`   | Directory starting from `root` and being a destination candidate. You can use glob syntax. (see [globby][glob-patterns] document) |
-| `ignore`                 | `string[]` | Directory to exclude from candidate output destination. You can use glob syntax. (see [globby][glob-patterns] document)           |
-| `questions`              | `object`   | Message to display when accepting input.                                                                                          |
+| key                      | type                       | description                                                                                                                       |
+| :----------------------- | :------------------------- | :-------------------------------------------------------------------------------------------------------------------------------- |
+| `name`<br />(required)   | `string`                   | Name of template.                                                                                                                 |
+| `root`<br />(required)   | `string`                   | The directory as the starting point of the output destination.                                                                    |
+| `output`<br />(required) | `string` <br /> `string[]` | Directory starting from `root` and being a destination candidate. You can use glob syntax. (see [globby][glob-patterns] document) |
+| `ignore`                 | `string[]`                 | Directory to exclude from candidate output destination. You can use glob syntax. (see [globby][glob-patterns] document)           |
+| `questions`              | `object`                   | Message to display when accepting input.                                                                                          |
 
 [glob-patterns]: https://github.com/sindresorhus/globby#globbing-patterns
 


### PR DESCRIPTION
<!-- Thank you for your contribution to scaffdog! Please replace {Please write here} with your description -->

## What does this do / why do we need it?

The `output` attribute actually can handle `string[]` but it is not documented.

## How does PR fix the problem?

Fixed document.

## What should your reviewer look out for in this PR?

The result of current PR is like
<img width="831" alt="SCR-20231103-iwcc" src="https://github.com/scaffdog/scaffdog/assets/16318727/f80f7f05-504d-42c8-b138-559b812cdbda">

I also tested union type but the width was not automatically adjusted.
<img width="826" alt="SCR-20231103-itoa-2" src="https://github.com/scaffdog/scaffdog/assets/16318727/9125904e-859b-4033-b204-66c7649d36cf">

I'm not sure which is better. It might be better to adjust some CSS.

## References

I read [this line](https://github.com/scaffdog/scaffdog/blob/68cdb4b5eeabe413f1256dbb935ec9f6917b0404/packages/scaffdog/src/commands/generate.ts#L124) and I thought it can handle array string.
