### PR TITLE
fix: correct parsing variable starting with `for`

### DIFF
--- a/packages/@scaffdog/engine/src/parser/statements.test.ts
+++ b/packages/@scaffdog/engine/src/parser/statements.test.ts
@@ -650,6 +650,19 @@ test.each<ParserTestEntry>([
     true,
     [],
   ],
+  [
+    'success',
+    '{{ formula }}',
+    createTagTemplate(
+      createTag('open', '{{', false, [0, 1]),
+      createExpressionStatement(createIdentifier('formula', [3, 9])),
+      createTag('close', '}}', false, [11, 12]),
+    ),
+    '',
+    13,
+    true,
+    [],
+  ],
   ['error', '{{ a', '', 4, true, [parseError('Missing "}}"', [4, 4])]],
 ])('tagTemplate - %s %s', (...args) => {
   expect(parse(tagTemplate, args[1])).toEqual(result(...args));

--- a/packages/@scaffdog/engine/src/parser/statements.ts
+++ b/packages/@scaffdog/engine/src/parser/statements.ts
@@ -48,6 +48,7 @@ import {
 import { whitespaceOrComment } from './comments.js';
 import { expression, identifier } from './expressions.js';
 import { tagClose, tagOpen } from './literals.js';
+import { whitespace1 } from './spaces.js';
 import type { Option, Parser, ParseResult, ParseState } from './types.js';
 
 // end, continue, break
@@ -233,6 +234,7 @@ export const forStatement: Parser<ForStatement> = (state) =>
   map(
     concat([
       string('for'),
+      whitespace1,
       whitespaceOrComment,
       cut(expected(forBinding, 'Missing expression after "for" keyword')),
       whitespaceOrComment,
@@ -253,6 +255,7 @@ export const forStatement: Parser<ForStatement> = (state) =>
     ]),
     (
       [
+        ,
         ,
         leading1,
         [value, index],


### PR DESCRIPTION
<!-- Thank you for your contribution to scaffdog! Please replace {Please write here} with your description -->

## What does this do / why do we need it?

When we use variables starting with `for`, such as `formula` and `forest`,  in tag template, we get an error below.

```
SyntaxError: "in" expected after expression:
```

## How does PR fix the problem?

In `for` statement, single whitespace will be required after `for` string.

## What should your reviewer look out for in this PR?

I confirmed that `if` statement doesn't have the same problem, so I'm not confident that this approach is appropriate.

## References

- Playground: https://scaff.dog/playground?code=H4sIAAAAAAAAA1NWCEssykxMykkt5uLSVUjLL8otzUm0UkgoSS0uSeDiUlZIqK5WyMwrKC0p1stLzE1VqK3VK6kASSUkJJRUFqQWJxdlFpRwAVVBNQNVgOS4AAy9ei1bAAAA&input=H4sIAAAAAAAAA4uuVspOrVSyUspLzE1V0lEqS8wpTQVyi5MT09JS8tOVamMBz%2B0iZCMAAAA%3D
