### PR TITLE
doc: fix section title to v4 from v3

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -5,7 +5,7 @@
 - [To v2 from v1](#to-v2-from-v1)
 - [To v1 from v0](#to-v1-from-v0)
 
-## To v3 from v2
+## To v4 from v3
 
 ### Node.js version
 


### PR DESCRIPTION
<!-- Thank you for your contribution to scaffdog! Please replace {Please write here} with your description -->

## What does this do / why do we need it?

Fixed an incorrect section title in the migration guide. The title was "to v3" but it should have been "to v4".

## How does PR fix the problem?

Updates the section title from "to v3" to "to v4".

## What should your reviewer look out for in this PR?

Please confirm that the section title has been correctly updated to "to v4" and that no other changes are necessary.

## References

- N/A
