### PR TITLE
chore: update React link in documentation example

### DIFF
--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -71,7 +71,7 @@ Let's define a little practical documentation and actually generate the files.
 
 ### Write your first template
 
-Let's take a [React](https://reactjs.org) project as an example for documentation.
+Let's take a [React](https://react.dev) project as an example for documentation.
 
 Create the `.scaffdog/component.md` file and edit it as follows:
 


### PR DESCRIPTION
<!-- Thank you for your contribution to scaffdog! Please replace {Please write here} with your description -->

## What does this do / why do we need it?

The URL to the React documentation in the documentation is out of date.
The documentation at this link is currently inaccessible and redirects.

## How does PR fix the problem?

The URLs listed in MDX have been changed to the new ones.

## What should your reviewer look out for in this PR?

Whether the URLs are appropriate. Whether the relevant URLs in the documentation have been changed to the desired ones after deployment.

## References

- Old React document link: [https://reactjs.org](https://reactjs.org)
- New React document link: [https://react.dev](https://react.dev)
